### PR TITLE
Upgrade to PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
           - ubuntu-22.04
         php-versions:
           - "8.1"
-          - "8.0"
-          - "7.4"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.1",
     "laravel/framework": "^8.0 || ^9.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.13",
-    "phpstan/phpstan": "^1.9"
+    "phpstan/phpstan": "^1.9",
+    "rector/rector": "^0.14.8"
   },
   "autoload": {
     "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+    ]);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_81);
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_81,
+        SetList::CODE_QUALITY,
+        SetList::PHP_81,
+        SetList::DEAD_CODE,
+    ]);
+};

--- a/src/Autodiscovery/LaravelPackageManifest.php
+++ b/src/Autodiscovery/LaravelPackageManifest.php
@@ -10,7 +10,7 @@ use InvalidManifestException;
 
 class LaravelPackageManifest extends PackageManifest
 {
-    public const PACKAGE_LOCK_FILE = 'autodiscovery.lock';
+    final public const PACKAGE_LOCK_FILE = 'autodiscovery.lock';
 
     public function fetchManifest(): Collection
     {

--- a/src/Autodiscovery/LaravelPackageManifest.php
+++ b/src/Autodiscovery/LaravelPackageManifest.php
@@ -2,7 +2,6 @@
 
 namespace Goedemiddag\AutodiscoveryLock\Autodiscovery;
 
-use Exception;
 use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Collection;
 use InvalidLockException;

--- a/src/Autodiscovery/ResolveResult.php
+++ b/src/Autodiscovery/ResolveResult.php
@@ -6,21 +6,13 @@ use Illuminate\Support\Collection;
 
 final class ResolveResult
 {
-    private Collection $notInLock;
-
-    private Collection $notInAutoload;
-
-    public function __construct(
-        Collection $notInLock,
-        Collection $notInAutoload,
-    ) {
-        $this->notInLock = $notInLock;
-        $this->notInAutoload = $notInAutoload;
+    public function __construct(private readonly Collection $notInLock, private readonly Collection $notInAutoload)
+    {
     }
 
     public function hasNoMismatches(): bool
     {
-        return $this->hasPackagesNotInAutoload() === false && $this->hasPackagesNotInLock() === false;
+        return !$this->hasPackagesNotInAutoload() && !$this->hasPackagesNotInLock();
     }
 
     public function hasPackagesNotInLock(): bool

--- a/src/Commands/AutodiscoveryPackageLock.php
+++ b/src/Commands/AutodiscoveryPackageLock.php
@@ -12,7 +12,7 @@ class AutodiscoveryPackageLock extends Command
     protected $signature = 'autodiscovery:generate-lock';
     protected $description = 'Generate a lock file for all autodiscovered packages';
 
-    private LaravelPackageManifest $packageManifest;
+    private readonly LaravelPackageManifest $packageManifest;
 
     public function __construct(PackageManifest $manifest)
     {

--- a/src/Commands/AutodiscoveryPackageLockVerify.php
+++ b/src/Commands/AutodiscoveryPackageLockVerify.php
@@ -13,10 +13,9 @@ class AutodiscoveryPackageLockVerify extends Command
     protected $signature = 'autodiscovery:verify-lock';
     protected $description = 'verify that the lockfile on disk is the same as the autodiscovered packages';
 
-    private LaravelPackageManifest $packageManifest;
-    private AutodiscoveryLockResolver $resolver;
+    private readonly LaravelPackageManifest $packageManifest;
 
-    public function __construct(PackageManifest $manifest, AutodiscoveryLockResolver $resolver)
+    public function __construct(PackageManifest $manifest, private readonly AutodiscoveryLockResolver $resolver)
     {
         parent::__construct();
 
@@ -25,7 +24,6 @@ class AutodiscoveryPackageLockVerify extends Command
             $manifest->basePath,
             $manifest->manifestPath ?? ''
         );
-        $this->resolver = $resolver;
     }
 
     public function handle(): int


### PR DESCRIPTION
Closes #19 

- Add Rector for automated upgrades and refactoring, and use a reasonable default config
- Remove unused imports
- Upgrade to PHP 8.1