### PR TITLE
Add config file for path and file name of lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,16 @@
     "friendsofphp/php-cs-fixer": "^3.13",
     "phpstan/phpstan": "^1.9",
     "rector/rector": "^0.14.8",
-    "phpunit/phpunit": "^9"
+    "orchestra/testbench": "^7.17"
   },
   "autoload": {
     "psr-4": {
       "Goedemiddag\\AutodiscoveryLock\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Goedemiddag\\AutodiscoveryLock\\Tests\\": "tests"
     }
   },
   "extra": {

--- a/config/autodiscovery.php
+++ b/config/autodiscovery.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'base_path' => base_path(),
+    'lock_filename' => 'autodiscovery.lock',
+];

--- a/src/Autodiscovery/AutodiscoveryLockServiceProvider.php
+++ b/src/Autodiscovery/AutodiscoveryLockServiceProvider.php
@@ -8,16 +8,16 @@ use Illuminate\Support\ServiceProvider;
 
 class AutodiscoveryLockServiceProvider extends ServiceProvider
 {
+    protected const CONFIG_PATH = __DIR__ . '/../../config/autodiscovery.php';
+
     public function register(): void
     {
-        $configPath = __DIR__ . '/../../config/autodiscovery.php';
-        $this->mergeConfigFrom($configPath, 'autodiscovery');
+        $this->mergeConfigFrom(self::CONFIG_PATH, 'autodiscovery');
     }
 
     public function boot(): void
     {
-        $configPath = __DIR__ . '/../../config/autodiscovery.php';
-        $this->publishes([$configPath => config_path('autodiscovery.php.')], 'config');
+        $this->publishes([self::CONFIG_PATH => config_path('autodiscovery.php.')], 'config');
 
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/src/Autodiscovery/AutodiscoveryLockServiceProvider.php
+++ b/src/Autodiscovery/AutodiscoveryLockServiceProvider.php
@@ -4,11 +4,21 @@ namespace Goedemiddag\AutodiscoveryLock\Autodiscovery;
 
 use Goedemiddag\AutodiscoveryLock\Commands\AutodiscoveryPackageLock;
 use Goedemiddag\AutodiscoveryLock\Commands\AutodiscoveryPackageLockVerify;
+use Illuminate\Support\ServiceProvider;
 
-class AutodiscoveryLockServiceProvider extends \Illuminate\Support\ServiceProvider
+class AutodiscoveryLockServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        $configPath = __DIR__ . '/../../config/autodiscovery.php';
+        $this->mergeConfigFrom($configPath, 'autodiscovery');
+    }
+
     public function boot(): void
     {
+        $configPath = __DIR__ . '/../../config/autodiscovery.php';
+        $this->publishes([$configPath => config_path('autodiscovery.php.')], 'config');
+
         if ($this->app->runningInConsole()) {
             $this->commands([
                 AutodiscoveryPackageLock::class,

--- a/src/Autodiscovery/LaravelPackageManifest.php
+++ b/src/Autodiscovery/LaravelPackageManifest.php
@@ -6,11 +6,10 @@ use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Collection;
 use InvalidLockException;
 use InvalidManifestException;
+use Symfony\Component\Filesystem\Path;
 
 class LaravelPackageManifest extends PackageManifest
 {
-    final public const PACKAGE_LOCK_FILE = 'autodiscovery.lock';
-
     public function fetchManifest(): Collection
     {
         return collect(parent::getManifest());
@@ -18,7 +17,10 @@ class LaravelPackageManifest extends PackageManifest
 
     public function getLockFilePath(): string
     {
-        return $this->basePath . DIRECTORY_SEPARATOR . self::PACKAGE_LOCK_FILE;
+        /** @var string $fileName */
+        $fileName = config('autodiscovery.lock_filename');
+
+        return Path::join($this->basePath, $fileName);
     }
 
     public function collectManifestFromComposerAutoload(): Collection

--- a/src/Commands/AutodiscoveryPackageLock.php
+++ b/src/Commands/AutodiscoveryPackageLock.php
@@ -3,6 +3,7 @@
 namespace Goedemiddag\AutodiscoveryLock\Commands;
 
 use Goedemiddag\AutodiscoveryLock\Autodiscovery\LaravelPackageManifest;
+use Goedemiddag\AutodiscoveryLock\Factories\LaravelPackageManifestFactory;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Collection;
@@ -14,15 +15,11 @@ class AutodiscoveryPackageLock extends Command
 
     private readonly LaravelPackageManifest $packageManifest;
 
-    public function __construct(PackageManifest $manifest)
+    public function __construct(PackageManifest $manifest, LaravelPackageManifestFactory $laravelPackageManifestFactory)
     {
         parent::__construct();
 
-        $this->packageManifest = new LaravelPackageManifest(
-            files: $manifest->files,
-            basePath: $manifest->basePath,
-            manifestPath: $manifest->manifestPath ?? ''
-        );
+        $this->packageManifest = $laravelPackageManifestFactory->build($manifest);
     }
 
     public function handle(): int

--- a/src/Commands/AutodiscoveryPackageLockVerify.php
+++ b/src/Commands/AutodiscoveryPackageLockVerify.php
@@ -4,6 +4,7 @@ namespace Goedemiddag\AutodiscoveryLock\Commands;
 
 use Goedemiddag\AutodiscoveryLock\Autodiscovery\AutodiscoveryLockResolver;
 use Goedemiddag\AutodiscoveryLock\Autodiscovery\LaravelPackageManifest;
+use Goedemiddag\AutodiscoveryLock\Factories\LaravelPackageManifestFactory;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Collection;
@@ -15,15 +16,14 @@ class AutodiscoveryPackageLockVerify extends Command
 
     private readonly LaravelPackageManifest $packageManifest;
 
-    public function __construct(PackageManifest $manifest, private readonly AutodiscoveryLockResolver $resolver)
-    {
+    public function __construct(
+        PackageManifest $manifest,
+        LaravelPackageManifestFactory $laravelPackageManifestFactory,
+        private readonly AutodiscoveryLockResolver $resolver
+    ) {
         parent::__construct();
 
-        $this->packageManifest = new LaravelPackageManifest(
-            files: $manifest->files,
-            basePath: $manifest->basePath,
-            manifestPath: $manifest->manifestPath ?? ''
-        );
+        $this->packageManifest = $laravelPackageManifestFactory->build($manifest);
     }
 
     public function handle(): int

--- a/src/Factories/LaravelPackageManifestFactory.php
+++ b/src/Factories/LaravelPackageManifestFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Goedemiddag\AutodiscoveryLock\Factories;
+
+use Goedemiddag\AutodiscoveryLock\Autodiscovery\LaravelPackageManifest;
+use Illuminate\Foundation\PackageManifest;
+
+class LaravelPackageManifestFactory
+{
+    public function build(PackageManifest $manifest): LaravelPackageManifest
+    {
+        /** @var string $basePath */
+        $basePath = config('autodiscovery.base_path', $manifest->basePath);
+
+        return new LaravelPackageManifest(
+            files: $manifest->files,
+            basePath: $basePath,
+            manifestPath: $manifest->manifestPath ?? ''
+        );
+    }
+}

--- a/tests/Autodiscovery/AutoDiscoveryLockResolverTest.php
+++ b/tests/Autodiscovery/AutoDiscoveryLockResolverTest.php
@@ -1,9 +1,12 @@
 <?php
 
+namespace Goedemiddag\AutodiscoveryLock\Tests\Autodiscovery;
+
 use Goedemiddag\AutodiscoveryLock\Autodiscovery\AutodiscoveryLockResolver;
+use Goedemiddag\AutodiscoveryLock\Tests\TestCase;
 use Illuminate\Support\Collection;
 
-final class AutoDiscoveryLockResolverTest extends \PHPUnit\Framework\TestCase
+final class AutoDiscoveryLockResolverTest extends TestCase
 {
     public function testGetClassesInLockfileMissingFromAutoload(): void
     {

--- a/tests/Autodiscovery/ResolveResultTest.php
+++ b/tests/Autodiscovery/ResolveResultTest.php
@@ -1,9 +1,12 @@
 <?php
 
+namespace Goedemiddag\AutodiscoveryLock\Tests\Autodiscovery;
+
 use Goedemiddag\AutodiscoveryLock\Autodiscovery\ResolveResult;
+use Goedemiddag\AutodiscoveryLock\Tests\TestCase;
 use Illuminate\Support\Collection;
 
-final class ResolveResultTest extends \PHPUnit\Framework\TestCase
+final class ResolveResultTest extends TestCase
 {
     public function testWithoutMismatches(): void
     {

--- a/tests/Factories/LaravelPackageManifestFactoryTest.php
+++ b/tests/Factories/LaravelPackageManifestFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Goedemiddag\AutodiscoveryLock\Tests\Factories;
+
+use Goedemiddag\AutodiscoveryLock\Autodiscovery\LaravelPackageManifest;
+use Goedemiddag\AutodiscoveryLock\Factories\LaravelPackageManifestFactory;
+use Goedemiddag\AutodiscoveryLock\Tests\TestCase;
+use Illuminate\Foundation\PackageManifest;
+use Symfony\Component\Filesystem\Path;
+
+class LaravelPackageManifestFactoryTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $laravelPackageManifestFactory = new LaravelPackageManifestFactory();
+        $packageManifest = resolve(PackageManifest::class);
+
+        $laravelPackageManifest = $laravelPackageManifestFactory->build($packageManifest);
+
+        $this->assertInstanceOf(LaravelPackageManifest::class, $laravelPackageManifest);
+        $this->assertSame(config('autodiscovery.base_path'), $laravelPackageManifest->basePath);
+        $this->assertSame(
+            Path::join(config('autodiscovery.base_path'), config('autodiscovery.lock_filename')),
+            $laravelPackageManifest->getLockFilePath()
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Goedemiddag\AutodiscoveryLock\Tests;
+
+use Goedemiddag\AutodiscoveryLock\Autodiscovery\AutodiscoveryLockServiceProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    /**
+     * Load the package service provider. This makes sure that, for example the config files are available.
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            AutodiscoveryLockServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
Closes #23 

@NiekKeijzer would you be so kind to review these changes as you've created the first tests?

Some information about the changes:

- Added a config file. I've decided to split the path and filename so it has less impact on the code. 
- The config file can be published and will be merged with the default one. This enables us to extend the config later on without breaking the application of the package users.
- Moved the initialization of the `LaravelPackageManifest` to a separate factory.
- Changed the tests to use the [orchestra/testbench](https://packages.tools/testbench/getting-started/introduction.html) package. This is a package specifically helpful in testing Laravel packages.
- Created a default `TestCase` which initializes the package's service provider (so it loads the config, etc.).
- Added namespace to tests, which is specified in the `autoload-dev` in `composer.json`.